### PR TITLE
[Feat] 호스트가 모임 참여자 리스트에 추가되었을 때 Exception 발생

### DIFF
--- a/src/main/java/com/team1/moim/domain/group/exception/HostIncludedException.java
+++ b/src/main/java/com/team1/moim/domain/group/exception/HostIncludedException.java
@@ -1,0 +1,15 @@
+package com.team1.moim.domain.group.exception;
+
+import com.team1.moim.global.exception.ErrorCode;
+import com.team1.moim.global.exception.MoimException;
+import lombok.Getter;
+
+@Getter
+public class HostIncludedException extends MoimException {
+
+    private static final ErrorCode errorCode = ErrorCode.HOST_INCLUDED;
+
+    public HostIncludedException() {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/team1/moim/global/exception/ErrorCode.java
+++ b/src/main/java/com/team1/moim/global/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
     PARTICIPANT_REQUIRED(HttpStatus.BAD_REQUEST, "모임 참여자를 1명 이상 등록해야 합니다."),
     PARTICIPANT_INFO_NOT_MATCH(HttpStatus.BAD_REQUEST, "모임 참여자 정보가 일치하지 않습니다."),
     ALREADY_VOTED(HttpStatus.BAD_REQUEST, "이미 투표하였습니다."),
+    HOST_INCLUDED(HttpStatus.BAD_REQUEST, "호스트는 모임 참여자에 추가할 수 없습니다."),
 
     // Member
     EMAIL_DUPLICATION(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),


### PR DESCRIPTION
## #️⃣연관된 이슈
> * #54 

## 📝작업한 내용

모임 생성 시 호스트가 모임 참여자에 포함된다면 HostIncludedException이 발생한다.

### 1. Postman으로 abbie, baker, chris 로그인

### 2. abbie, baker, chris 모두 SSE 연결 맺기

![image](https://github.com/HanHwa-Team1-Final-Project/Team1-BE/assets/27791880/e0650ca4-9aeb-42db-84b8-fef97d029c30)

![image](https://github.com/HanHwa-Team1-Final-Project/Team1-BE/assets/27791880/8751bb19-a208-4e9b-b800-170018486172)

![image](https://github.com/HanHwa-Team1-Final-Project/Team1-BE/assets/27791880/3ad849d5-8bef-4779-855e-b0bca26d56d4)

### 3. abbie가 모임 생성(abbie가 host인 경우)

![image](https://github.com/HanHwa-Team1-Final-Project/Team1-BE/assets/27791880/6335fa0e-346c-4873-bd96-693765011b08)

### 4. 호스트가 참여자 리스트에 포함되어 있기 때문에 400 Bad Request와 함께 HostIncludedException이 발생함

![image](https://github.com/HanHwa-Team1-Final-Project/Team1-BE/assets/27791880/0e10b777-c17f-4357-85d2-bafd60403f1e)


## PR 종류
> 어떤 종류의 PR인지 아래 항목 중에 체크
- [x] 기능 추가

<br/>
<br/>

> * close #54
> * close #42